### PR TITLE
test: harden flaky restart and startup checks

### DIFF
--- a/internal/embeddedstore/engine_test.go
+++ b/internal/embeddedstore/engine_test.go
@@ -358,7 +358,13 @@ func TestEngine_StartPeriodicCheckpointPersistsRestartableStateWithoutFlush(t *t
 		if err != nil {
 			return false
 		}
-		return len(manifest.Checkpoints) >= 1
+		if len(manifest.Checkpoints) == 0 {
+			return false
+		}
+		checkpoint := latestCheckpointMeta(manifest.Checkpoints)
+		return checkpoint.HighWaterMark == 1 &&
+			manifest.ActiveTail.BaseHighWaterMark == checkpoint.HighWaterMark &&
+			manifest.ActiveTail.EventCount == 0
 	}, time.Second, 10*time.Millisecond)
 
 	manifest, err := loadOrCreateManifest(rootDir)

--- a/tests/e2e/helpers/testcontext.go
+++ b/tests/e2e/helpers/testcontext.go
@@ -97,20 +97,34 @@ func (tc *TestContext) ReconnectPortForward() error {
 		serviceName = fmt.Sprintf("%s-spectre", tc.SharedDeployment.ReleaseName)
 	}
 
-	// Create new port-forward
-	portForwarder, err := NewPortForwarder(tc.t, tc.Cluster.GetContext(), namespace, serviceName, defaultServicePort)
-	if err != nil {
-		return fmt.Errorf("failed to create new port-forward: %w", err)
-	}
-	if err := portForwarder.WaitForReady(30 * time.Second); err != nil {
-		return fmt.Errorf("service not reachable via new port-forward: %w", err)
+	var lastErr error
+	deadline := time.Now().Add(30 * time.Second)
+
+	for time.Now().Before(deadline) {
+		portForwarder, err := NewPortForwarder(tc.t, tc.Cluster.GetContext(), namespace, serviceName, defaultServicePort)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to create new port-forward: %w", err)
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		if err := portForwarder.WaitForReady(30 * time.Second); err != nil {
+			lastErr = fmt.Errorf("service not reachable via new port-forward: %w", err)
+			_ = portForwarder.Stop()
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+
+		tc.PortForward = portForwarder
+		tc.APIClient = NewAPIClient(tc.t, portForwarder.GetURL())
+
+		tc.t.Logf("✓ Port-forward reconnected to new pod")
+		return nil
 	}
 
-	tc.PortForward = portForwarder
-	tc.APIClient = NewAPIClient(tc.t, portForwarder.GetURL())
-
-	tc.t.Logf("✓ Port-forward reconnected to new pod")
-	return nil
+	if lastErr == nil {
+		lastErr = fmt.Errorf("timed out waiting for replacement port-forward")
+	}
+	return lastErr
 }
 
 // SetupE2ETestWithValuesFile provisions test infrastructure using a custom Helm values file.

--- a/tests/integration/api/embedded_runtime_fast_restart_test.go
+++ b/tests/integration/api/embedded_runtime_fast_restart_test.go
@@ -47,9 +47,9 @@ func TestEmbeddedRuntimeFastRestartServesTimelineImmediately(t *testing.T) {
 	require.Equal(t, 1.0, gaugeValueFromFamilies(t, families, "spectre_embedded_active_tail_events", nil))
 
 	manifestAfterReopen := readEmbeddedManifest(t, dir)
-	require.Equal(t, 1, manifestAfterReopen.SegmentIndexGeneration)
-	manifestBeforeReopen.SegmentIndexGeneration = manifestAfterReopen.SegmentIndexGeneration
-	require.Equal(t, manifestBeforeReopen, manifestAfterReopen)
+	require.Equal(t, manifestBeforeReopen.ActiveCheckpoint, manifestAfterReopen.ActiveCheckpoint)
+	require.Equal(t, manifestBeforeReopen.ActiveTail, manifestAfterReopen.ActiveTail)
+	require.Equal(t, manifestBeforeReopen.Checkpoints, manifestAfterReopen.Checkpoints)
 
 	server := newEmbeddedRuntimeServer(t, engine)
 	response := queryEmbeddedTimeline(t, server, 0, 1_000_000)


### PR DESCRIPTION
## Summary
- wait for periodic checkpoint tests to observe the post-rotation manifest state
- stop fast-restart integration from asserting on async segment-index migration timing
- retry port-forward reconnection after Spectre pod restarts in e2e

## Verification
- `go test -count=50 -run TestEngine_StartPeriodicCheckpointPersistsRestartableStateWithoutFlush ./internal/embeddedstore`
- `go test -count=50 -run TestEmbeddedRuntimeFastRestartServesTimelineImmediately ./tests/integration/api`
- `go test -v -count=1 -timeout 60m ./tests/e2e -run TestScenarioPodRestart`
- `go test -v -cover -count=1 -timeout 60m ./...`
- `cd ui && npm run test`
- `cd ui && npx playwright install chromium && npm run test:ct`